### PR TITLE
Add .travis yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+  - "3.2"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.5-dev" # 3.5 development branch
+  - "nightly" # currently points to 3.6-dev
+
+  - "pypy"
+  - "pypy3"
+
+# command to install dependencies (we have none right now)
+install: python setup.py develop
+
+# command to run tests
+script: nosetests

--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ Changelog
     * Added channel unsubscribe helper: channel.unsubscribe()
     * Each published message now has a unique incrementing ID
 
+
+Build status
+============
+[![Build status][ci-image]][ci-url]
+[ci-image]: https://travis-ci.org/stuaxo/pubsub.png?branch=master
+[ci-url]: https://travis-ci.org/stuaxo/pubsub
+
+
 The MIT License
 ===============
 


### PR DESCRIPTION
Adds .travis yml and build status to README.

If you accept this and want the status in the README to work, you need to set the username in that file to `nehz` + add the repo on  https://travis-ci.org  .. this way tests are run on every py version on commit.
