### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,10 @@ setup(
     name='pubsub',
     version='0.1.2',
     description='Simple Python PubSub',
+    long_description='Python In-Process messaging, with filtering by topic.',
     author='Zhen Wang',
     author_email='mail@zhenwang.info',
+    license='MIT',
     url='https://github.com/nehz/pubsub',
     py_modules=['pubsub'],
     install_requires=[


### PR DESCRIPTION
Add long_description and license fields so that stdeb can work better.

With long_description a deb package can be generated without an error about the description field.
The license field, should make it possible to generate an copyright file with a script.